### PR TITLE
aw - Added Get endpoint for UCSB Organization

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
@@ -48,6 +48,22 @@ public class UCSBOrganizationController extends ApiController {
     }
 
     /**
+     * This method returns a single organization.
+     * @param orgCode code of the organization
+     * @return a single organization
+     */
+    @Operation(summary= "Get a single organization")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("")
+    public UCSBOrganization getById(
+            @Parameter(name="orgCode") @RequestParam String orgCode) {
+        UCSBOrganization organization = ucsbOrganizationRepository.findById(orgCode)
+                .orElseThrow(() -> new EntityNotFoundException(UCSBOrganization.class, orgCode));
+
+        return organization;
+    }
+
+    /**
      * This method creates a new organization. Accessible only to users with the role "ROLE_ADMIN".
      * @param orgCode code of the organization
      * @param orgTranslationShort short translation of the organization

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
@@ -55,6 +55,12 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
                                 .andExpect(status().is(200)); // logged
         }
 
+        @Test
+        public void logged_out_users_cannot_get_by_id() throws Exception {
+                mockMvc.perform(get("/api/ucsborganization?orgCode=sbHacks"))
+                                .andExpect(status().is(403)); // logged out users can't get by id
+        }
+
          // Authorization tests for /api/ucsborganization/post
         // (Perhaps should also have these for put and delete)
 
@@ -62,6 +68,56 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
         public void logged_out_users_cannot_post() throws Exception {
                 mockMvc.perform(post("/api/ucsborganization/post"))
                                 .andExpect(status().is(403));
+        }
+        
+
+        // Tests with mocks for database actions
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
+
+                // arrange
+
+                UCSBOrganization sbHacks = UCSBOrganization.builder()
+                                .orgCode("SBHacks")
+                                .orgTranslationShort("SBHacks: UCSB")
+                                .orgTranslation("SB Hacks: UCSB's Largest Hackathon")
+                                .inactive(true)
+                                .build();
+
+                when(ucsbOrganizationRepository.findById(eq("SBHacks"))).thenReturn(Optional.of(sbHacks));
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/ucsborganization?orgCode=SBHacks"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(ucsbOrganizationRepository, times(1)).findById(eq("SBHacks"));
+                String expectedJson = mapper.writeValueAsString(sbHacks);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+        
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+
+                // arrange
+
+                when(ucsbOrganizationRepository.findById(eq("DataScienceClub"))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/ucsborganization?orgCode=DataScienceClub"))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+
+                verify(ucsbOrganizationRepository, times(1)).findById(eq("DataScienceClub"));
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("EntityNotFoundException", json.get("type"));
+                assertEquals("UCSBOrganization with id DataScienceClub not found", json.get("message"));
         }
 
         @WithMockUser(roles = { "USER" })


### PR DESCRIPTION
In this PR, we add the get by id endpoint and tests for UCSB Organization. Logged in users will be able to retrieve information about an organization by the id / orgCode.

Passes line coverage and mutation coverage. Is deployed at https://team01-dev-ameymwalimbe.dokku-00.cs.ucsb.edu

Closes #58 